### PR TITLE
HTTP 활용하기

### DIFF
--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -133,7 +133,6 @@ public class Http11Processor implements Runnable, Processor {
                 OutputStream outputStream = connection.getOutputStream();
                 BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
         ) {
-
             Http11Request request = makeRequest(bufferedReader);
             get(request, outputStream);
         } catch (IOException e) {
@@ -148,7 +147,6 @@ public class Http11Processor implements Runnable, Processor {
         String url = rawStart[URL_SEQUENCE];
 
         Map<String, String> headers = parseHeaders(bufferedReader);
-
         String body = parseBody(bufferedReader);
 
         return new Http11Request(method, url, headers, body);

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -5,8 +5,17 @@ import org.apache.coyote.Processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.Socket;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Http11Processor implements Runnable, Processor {
 
@@ -24,9 +33,27 @@ public class Http11Processor implements Runnable, Processor {
     }
 
     @Override
-    public void process(final Socket connection) {
+    public void process(final Socket connection){
         try (final var inputStream = connection.getInputStream();
-             final var outputStream = connection.getOutputStream()) {
+             final var outputStream = connection.getOutputStream();
+             final var inputStreamReader = new InputStreamReader(inputStream);
+             final var bufferedReader = new BufferedReader(inputStreamReader)) {
+
+
+            String[] startLine = bufferedReader.readLine().split(" ");
+            if (startLine[0].equals("GET") && startLine[1].equals("/index.html")) {
+                URL resource = getClass().getClassLoader().getResource("static/index.html");
+
+                final var response = "HTTP/1.1 200 OK \r\n" +
+                        "Content-Type: text/html;charset=utf-8 \r\n" +
+                        "Content-Length: 5564 \r\n" +
+                        "\r\n"+
+                        new String(Files.readAllBytes(new File(resource.getFile()).toPath()));
+
+                outputStream.write(response.getBytes());
+                outputStream.flush();
+                return;
+            }
 
             final var responseBody = "Hello world!";
 

--- a/tomcat/src/main/java/org/apache/coyote/http11/HttpContent.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/HttpContent.java
@@ -23,10 +23,6 @@ public enum HttpContent {
                 .orElse("text/plain");
     }
 
-    public String getExtension() {
-        return extension;
-    }
-
     public String getContentType() {
         return contentType;
     }

--- a/tomcat/src/main/java/org/apache/coyote/http11/HttpContent.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/HttpContent.java
@@ -22,4 +22,12 @@ public enum HttpContent {
                 .findAny()
                 .orElse("text/plain");
     }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/HttpContent.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/HttpContent.java
@@ -1,0 +1,25 @@
+package org.apache.coyote.http11;
+
+import java.util.Arrays;
+
+public enum HttpContent {
+    CSS("css", "text/css"),
+    JAVASCRIPT("js", "application/javascript"),
+    HTML("html", "text/html");
+
+    private final String extension;
+    private final String contentType;
+
+    HttpContent(String extension, String contentType) {
+        this.extension = extension;
+        this.contentType = contentType;
+    }
+
+    public static String extensionToContentType(String extension) {
+        return Arrays.stream(values())
+                .filter(value -> value.extension.equals(extension))
+                .map(value -> value.contentType)
+                .findAny()
+                .orElse("text/plain");
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/HttpHeaders.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/HttpHeaders.java
@@ -1,0 +1,16 @@
+package org.apache.coyote.http11;
+
+public enum HttpHeaders {
+    CONTENT_TYPE("Content-Type"),
+    CONTENT_LENGTH("Content-Length");
+
+    private final String headerName;
+
+    HttpHeaders(String headerName) {
+        this.headerName = headerName;
+    }
+
+    public String getHeaderName() {
+        return headerName;
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/HttpStatus.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/HttpStatus.java
@@ -1,0 +1,21 @@
+package org.apache.coyote.http11;
+
+public enum HttpStatus {
+    OK(200, "OK");
+
+    private final int statusCode;
+    private final String message;
+
+    HttpStatus(int statusCode, String message) {
+        this.statusCode = statusCode;
+        this.message = message;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/request/Http11Request.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/request/Http11Request.java
@@ -1,5 +1,7 @@
 package org.apache.coyote.http11.request;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class Http11Request {
@@ -22,6 +24,23 @@ public class Http11Request {
     public String getUrl() {
         return url;
     }
+
+    public Map<String, String> getQueryString() {
+        int queryIndex = url.indexOf("?");
+        if (queryIndex == -1) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> queries = new HashMap<>();
+        String rawQuery = url.substring(queryIndex + 1);
+        for (String query : rawQuery.split("&")) {
+            String[] temp = query.split("=");
+            queries.put(temp[0].toLowerCase(), temp[1].toLowerCase());
+        }
+
+        return queries;
+    }
+
 
     @Override
     public String toString() {

--- a/tomcat/src/main/java/org/apache/coyote/http11/request/Http11Request.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/request/Http11Request.java
@@ -1,0 +1,25 @@
+package org.apache.coyote.http11.request;
+
+import java.util.Map;
+
+public class Http11Request {
+    private final String method;
+    private final String url;
+    private final Map<String, String> header;
+    private final String body;
+
+    public Http11Request(String method, String url, Map<String, String> header, String body) {
+        this.method = method;
+        this.url = url;
+        this.header = header;
+        this.body = body;
+    }
+
+    public boolean isResource() {
+        return url.endsWith(".html") || url.endsWith(".css") || url.endsWith(".js");
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/request/Http11Request.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/request/Http11Request.java
@@ -22,4 +22,14 @@ public class Http11Request {
     public String getUrl() {
         return url;
     }
+
+    @Override
+    public String toString() {
+        return "Http11Request{" +
+                "method='" + method + '\'' +
+                ", url='" + url + '\'' +
+                ", header=" + header +
+                ", body='" + body + '\'' +
+                '}';
+    }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/Http11Response.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/Http11Response.java
@@ -29,6 +29,7 @@ public class Http11Response {
         }
         stringBuilder.append("\r\n");
         stringBuilder.append(body);
+        stringBuilder.append("\r\n");
 
         return stringBuilder.toString();
     }

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/Http11Response.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/Http11Response.java
@@ -1,0 +1,35 @@
+package org.apache.coyote.http11.response;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class Http11Response {
+
+    private final String protocolVersion;
+    private final int statusCode;
+    private final String statusMessage;
+    private final Map<String, String> responseHeader;
+    private final String body;
+
+    public Http11Response(String protocolVersion, int statusCode, String statusMessage,
+                          Map<String, String> responseHeader,
+                          String body) {
+        this.protocolVersion = protocolVersion;
+        this.statusCode = statusCode;
+        this.statusMessage = statusMessage;
+        this.responseHeader = responseHeader;
+        this.body = body;
+    }
+
+    public String toMessage() {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(protocolVersion + " " + statusCode + " " + statusMessage + " \r\n");
+        for (Entry<String, String> entry : responseHeader.entrySet()) {
+            stringBuilder.append(entry.getKey() + ": " + entry.getValue() + " \r\n");
+        }
+        stringBuilder.append("\r\n");
+        stringBuilder.append(body);
+
+        return stringBuilder.toString();
+    }
+}

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/Http11Response.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/Http11Response.java
@@ -21,6 +21,12 @@ public class Http11Response {
         this.body = body;
     }
 
+    public Http11Response(int statusCode, String statusMessage,
+                          Map<String, String> responseHeader,
+                          String body) {
+        this("HTTP/1.1", statusCode, statusMessage, responseHeader, body);
+    }
+
     public String toMessage() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append(protocolVersion + " " + statusCode + " " + statusMessage + " \r\n");

--- a/tomcat/src/test/java/study/FileTest.java
+++ b/tomcat/src/test/java/study/FileTest.java
@@ -1,13 +1,18 @@
 package study;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Scanner;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.nio.file.Path;
-import java.util.Collections;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * 웹서버는 사용자가 요청한 html 파일을 제공 할 수 있어야 한다.
@@ -26,7 +31,8 @@ class FileTest {
         final String fileName = "nextstep.txt";
 
         // todo
-        final String actual = "";
+        final String actual = getClass().getClassLoader().getResource("nextstep.txt")
+                        .getFile();
 
         assertThat(actual).endsWith(fileName);
     }
@@ -36,14 +42,18 @@ class FileTest {
      * File, Files 클래스를 사용하여 파일의 내용을 읽어보자.
      */
     @Test
-    void 파일의_내용을_읽는다() {
+    void 파일의_내용을_읽는다() throws IOException, URISyntaxException {
         final String fileName = "nextstep.txt";
 
         // todo
-        final Path path = null;
+        final Path path = Paths.get(Objects.requireNonNull(getClass().getClassLoader().getResource(fileName)).toURI());
 
         // todo
-        final List<String> actual = Collections.emptyList();
+        final List<String> actual = new ArrayList<>();
+
+        try (Scanner scanner = new Scanner(path.toFile())) {
+            actual.add(scanner.nextLine());
+        }
 
         assertThat(actual).containsOnly("nextstep");
     }

--- a/tomcat/src/test/java/study/IOStreamTest.java
+++ b/tomcat/src/test/java/study/IOStreamTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -51,6 +52,7 @@ class IOStreamTest {
              * todo
              * OutputStream 객체의 write 메서드를 사용해서 테스트를 통과시킨다
              */
+            outputStream.write(bytes);
 
             final String actual = outputStream.toString();
 
@@ -75,6 +77,7 @@ class IOStreamTest {
              * flush를 사용해서 테스트를 통과시킨다.
              * ByteArrayOutputStream과 어떤 차이가 있을까?
              */
+            outputStream.flush();
 
             verify(outputStream, atLeastOnce()).flush();
             outputStream.close();
@@ -93,6 +96,7 @@ class IOStreamTest {
              * try-with-resources를 사용한다.
              * java 9 이상에서는 변수를 try-with-resources로 처리할 수 있다.
              */
+            outputStream.close();
 
             verify(outputStream, atLeastOnce()).close();
         }
@@ -123,7 +127,7 @@ class IOStreamTest {
              * todo
              * inputStream에서 바이트로 반환한 값을 문자열로 어떻게 바꿀까?
              */
-            final String actual = "";
+            final String actual = new String(inputStream.readAllBytes());
 
             assertThat(actual).isEqualTo("🤩");
             assertThat(inputStream.read()).isEqualTo(-1);
@@ -143,6 +147,7 @@ class IOStreamTest {
              * try-with-resources를 사용한다.
              * java 9 이상에서는 변수를 try-with-resources로 처리할 수 있다.
              */
+            inputStream.close();
 
             verify(inputStream, atLeastOnce()).close();
         }
@@ -165,7 +170,7 @@ class IOStreamTest {
         void 필터인_BufferedInputStream를_사용해보자() {
             final String text = "필터에 연결해보자.";
             final InputStream inputStream = new ByteArrayInputStream(text.getBytes());
-            final InputStream bufferedInputStream = null;
+            final InputStream bufferedInputStream = new BufferedInputStream(inputStream);
 
             final byte[] actual = new byte[0];
 
@@ -188,15 +193,22 @@ class IOStreamTest {
          * 필터인 BufferedReader를 사용하면 readLine 메서드를 사용해서 문자열(String)을 한 줄 씩 읽어올 수 있다.
          */
         @Test
-        void BufferedReader를_사용하여_문자열을_읽어온다() {
+        void BufferedReader를_사용하여_문자열을_읽어온다() throws IOException {
             final String emoji = String.join("\r\n",
                     "😀😃😄😁😆😅😂🤣🥲☺️😊",
                     "😇🙂🙃😉😌😍🥰😘😗😙😚",
                     "😋😛😝😜🤪🤨🧐🤓😎🥸🤩",
                     "");
             final InputStream inputStream = new ByteArrayInputStream(emoji.getBytes());
+            final InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
+            final BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
 
             final StringBuilder actual = new StringBuilder();
+            String data = "";
+            while ((data = bufferedReader.readLine()) != null) {
+                actual.append(data);
+                actual.append("\r\n");
+            }
 
             assertThat(actual).hasToString(emoji);
         }

--- a/tomcat/src/test/java/study/IOStreamTest.java
+++ b/tomcat/src/test/java/study/IOStreamTest.java
@@ -167,12 +167,14 @@ class IOStreamTest {
          * 버퍼 크기를 지정하지 않으면 버퍼의 기본 사이즈는 얼마일까?
          */
         @Test
-        void 필터인_BufferedInputStream를_사용해보자() {
+        void 필터인_BufferedInputStream를_사용해보자() throws IOException {
             final String text = "필터에 연결해보자.";
             final InputStream inputStream = new ByteArrayInputStream(text.getBytes());
             final InputStream bufferedInputStream = new BufferedInputStream(inputStream);
 
-            final byte[] actual = new byte[0];
+            final byte[] actual = new byte[text.getBytes().length];
+
+            bufferedInputStream.read(actual);
 
             assertThat(bufferedInputStream).isInstanceOf(FilterInputStream.class);
             assertThat(actual).isEqualTo("필터에 연결해보자.".getBytes());


### PR DESCRIPTION
캐싱이나 압축, ETag등 모두 http 학습을 하면서 개념적으로는 어느정도 공부를 했지만, 
스프링 부트에 실어서 적용해 본 경험은 처음이라 많이 헤맸던 것 같습니다 ^^;;;😱

복잡한 개념들인데도 불구하고 스프링에서 쉽게 적용할 수 있는걸 보고, 다시 한번 스프링을 사용하는 것이
얼마나 편리한 것인지 알게 되지 않았나 싶습니다ㅋㅋ.. 또한 학습이 조금 부족한 것 같아 학습을 좀 더 늘려야 할 것 같습니다!
아래는 학습 로그입니다~

---

### Cache-Control 설정

---

HTTP Get 메서드로 얻어온 자원에 대해서 웹 브라우저에서 캐시를 사용하도록 설정할 수 있습니다. 이번 예시에서는 캐시를 사용하지 않도록 하는 방법을 제시합니다. Cache-Control을 no-cache, no-store로 등록할 수 있지만, no-store의 경우에는 중간 서버에서 캐싱을 해주는 휴리스틱 캐시가 발생할 수 있으므로 유의해야 합니다.

```java
@Configuration
public class CacheWebConfig implements WebMvcConfigurer {

    @Override
    public void addInterceptors(final InterceptorRegistry registry) {
        registry.addInterceptor(new CacheIgnore())
                .addPathPatterns("**");
    }

    private class CacheIgnore implements HandlerInterceptor {
        @Override
        public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
                throws Exception {
            response.setHeader(HttpHeaders.CACHE_CONTROL, CacheControl.noCache().cachePrivate().getHeaderValue());
            return true;
        }

        @Override
        public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
                               ModelAndView modelAndView) throws Exception {
            HandlerInterceptor.super.postHandle(request, response, handler, modelAndView);
        }

        @Override
        public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler,
                                    Exception ex) throws Exception {
            HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
        }
    }
}
```

### HTTP Compression

---

HTTP의 성능을 높이기 위해서는 전달하는 데이터의 크기를 줄이기 위해 압축을 할 수 있습니다. 이 때, 스프링 부트의 간단한 설정을 통해 gzip 알고리즘을 사용할 수 있습니다. 압축이 되었다면 응답 헤더 중 `Content-Encoding 헤더`에 `gzip` 값이 할당됩니다.

```java
server:
  compression:
    enabled: true
    min-response-size: 10
```

### ETag

---

ETag란 특정 버전의 리소스를 식별하는 식별자입니다. 웹 서버가 ETag가 변하지 않았다면 해당 리소스를 가져오지 않으므로 효율적으로 캐싱할 수 있습니다. 특정 URL의 리소스가 변경된다면 ETag도 변경됩니다.

스프링 부트에서는 FilterRegistrationBean을 등록함으로써 ETag 설정을 해줄 수 있습니다.

```java
@Configuration
public class EtagFilterConfiguration {

    @Bean
    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
        FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter = new FilterRegistrationBean<>(
                new ShallowEtagHeaderFilter());

        shallowEtagHeaderFilter.addUrlPatterns(
                "/etag",
                "ㅊ/etag/*",
                "/resources/*"
        );
        return shallowEtagHeaderFilter;
    }
}
```

### 캐시 무효화

---

캐시 무효화(cache busting)은 unique file version identifier을 사용하여 브라우저에게 새로운 버전이 있음을 알려주는 방식입니다. cache busting은 file name versioning(style.v2.css), file path versioning(/v2/style.css), query string(style.css?ver=2) 방식이 존재합니다. 

이번 예제에서는 두번째 방식인 `file path versioning 기법`을 사용합니다.

```java
@Override
public void addResourceHandlers(final ResourceHandlerRegistry registry) {
    registry.addResourceHandler(PREFIX_STATIC_RESOURCES + "/" + version.getVersion() + "/**")
            .setCacheControl(CacheControl.maxAge(Duration.ofDays(365)).cachePublic())
            .addResourceLocations("classpath:/static/");
}
```